### PR TITLE
Add www.lightdatasys.com to nginx config

### DIFF
--- a/roles/lidsys-web/templates/nginx/conf.d/lightdatasys.com.conf.j2
+++ b/roles/lidsys-web/templates/nginx/conf.d/lightdatasys.com.conf.j2
@@ -1,6 +1,6 @@
 server {
     listen      {{ nginx_default_port }};
-    server_name lightdatasys.com{{ domain_suffix }};
+    server_name lightdatasys.com{{ domain_suffix }} www.lightdatasys.com{{ domain_suffix }};
     index       index.php;
 
     root /var/www/html/lidsys-web/public;


### PR DESCRIPTION
Currently www.lightdatasys.com shows the default nginx page
