### PR TITLE
Listen on IPv6 address/port for Lidsys nginx

### DIFF
--- a/roles/lidsys-web/templates/nginx/conf.d/lightdatasys.com.conf.j2
+++ b/roles/lidsys-web/templates/nginx/conf.d/lightdatasys.com.conf.j2
@@ -1,5 +1,6 @@
 server {
     listen      {{ nginx_default_port }};
+    listen      [::]:{{ nginx_default_port }};
     server_name lightdatasys.com{{ domain_suffix }} www.lightdatasys.com{{ domain_suffix }};
     index       index.php;
 


### PR DESCRIPTION
Hitting localhost:8081 causes the address to bounce
between IPv4 and IPv6, but if Lidsys's nginx is not
listening on IPv6 the default nginx virtual server
will end up responding.
